### PR TITLE
[version-name] Try stripping .0 patch version to find a matching Xcode

### DIFF
--- a/libexec/xcenv-version-name
+++ b/libexec/xcenv-version-name
@@ -61,10 +61,24 @@ fi
 XCODE_APP="$(find_xcode_app_from_version "$XCENV_VERSION")"
 if [ -n "$XCODE_APP" ]; then
   return_xcenv_version "${XCODE_APP}"
-elif [ -n "$1" ]; then
-  echo "xcenv: version \`$XCENV_VERSION' is not installed" >&2
-  exit 1
 else
-  echo "xcenv: version \`$XCENV_VERSION' is not installed (set by $(xcenv-version-origin))" >&2
-  exit 1
+  # If the specified version is formatted as X.X.0, strip the final .0 and re-check whether
+  # an installed Xcode version exists
+  if [[ "$XCENV_VERSION" =~ ^([1-9][0-9]*\.)([0-9]*)(\.0)$ ]]; then
+    STRIPPED_XCENV_VERSION=${XCENV_VERSION:0:$((${#XCENV_VERSION} - 2))}
+    XCODE_APP="$(find_xcode_app_from_version "$STRIPPED_XCENV_VERSION")"
+
+    if [ -n "$XCODE_APP" ]; then
+      return_xcenv_version "${XCODE_APP}"
+      exit 0
+    fi
+  fi
+
+  if [ -n "$1" ]; then
+    echo "xcenv: version \`$XCENV_VERSION' is not installed" >&2
+    exit 1
+  else
+    echo "xcenv: version \`$XCENV_VERSION' is not installed (set by $(xcenv-version-origin))" >&2
+    exit 1
+  fi
 fi

--- a/test/stub_helper.bash
+++ b/test/stub_helper.bash
@@ -65,7 +65,8 @@ stub_list_of_xcodes() {
     echo Xcode6.3.app
     echo Xcode6.4.app
     echo Xcode7.2.app
-    echo Xcode-beta.app"
+    echo Xcode-beta.app
+    echo Xcode11.app"
   
   CODE=`cat <<fi
     if [ "\\$1" = "Xcode.app" ]; then
@@ -78,8 +79,10 @@ stub_list_of_xcodes() {
       echo "7.2"
     elif [ "\\$1" = "Xcode-beta.app" ]; then
       echo "8.0b"
+    elif [ "\\$1" = "Xcode11.app" ]; then
+      echo "11.0"
     else
-      echo "Unkown app: \\$1"
+      echo "Unknown app: \\$1"
     fi
   `
   stub_executable "xcenv-xcode-version" "$CODE"

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -65,6 +65,16 @@ run_command() {
   assert_failure "xcenv: version \`5.0' is not installed"
 }
 
+@test "version-name strips .0 from a X.X.0 version if corresponding Xcode can't be found" {
+  run_command 7.2.0
+  assert_output "Xcode7.2.app"
+}
+
+@test "version-name doesn't strip .0 from a X.0 version" {
+  run_command 11.0
+  assert_output "Xcode11.app"
+}
+
 @test "version-name returns error if not found and set by xcode-version file" {
   stub_executable_success "xcenv-version-file" ".xcode-version"
   stub_executable_success "xcenv-version-file-read" "5.0"


### PR DESCRIPTION
The purpose of this PR is to add handling to **xcenv-version-name** to account for versions specified as **X.X.0**. Even though Xcode's CFBundleShortVersionString tends to drop the trailing patch number in the version specifier, it's conceivable that someone might want to include the patch version in their command for the sake of consistency (i.e.: 11.6.0, 11.6.1 etc).

This functionality has been written such that it doesn't assume that Apple will continue the pattern of dropping the patch version in Xcode's CFBundleShortVersionString, however, this means that in all cases of a failed version match, the **find_xcode_app_from_version** function will be run twice. Instead, if we accept the aforementioned assumption, we can simply check whether the version passed into the command meets the **X.X.0** format and simply drop the patch version immediately. Happy to take feedback on this!

- [X] I have read the [Contribution Guidelines](https://github.com/xcenv/xcenv/blob/master/CONTRIBUTING.md)